### PR TITLE
Add loading icon w hen rabbitmq has not initialized

### DIFF
--- a/backend/match_service/run-dev.sh
+++ b/backend/match_service/run-dev.sh
@@ -2,4 +2,4 @@ set -o allexport
 source ../../docker-compose-dev.env
 set +o allexport
 
-nodemon server.js
+nodemon server.js & nodemon ./matchmaking/index.js

--- a/frontend/src/components/common/CoolButton.js
+++ b/frontend/src/components/common/CoolButton.js
@@ -41,7 +41,9 @@ function CoolButton(props) {
 						<LoadingIcon text={text} />
 					</div>
 				) : (
-					<span style={{ color: mode === "dark" ? "white" : "black" }}>
+					<span
+						style={{ color: mode === "dark" ? "white" : "black" }}
+					>
 						{text}
 					</span>
 				)}

--- a/frontend/src/components/services/Match.js
+++ b/frontend/src/components/services/Match.js
@@ -14,7 +14,8 @@ var timeout_id = null;
 function Match() {
 	const { setOpenSnackBar, setSB } = useContext(SnackBarContext);
 	const { setQuestion } = useContext(QuestionContext);
-	const { match, findMatch, hasInit, setFindMatch } = useContext(MatchContext);
+	const { match, findMatch, hasInit, setFindMatch } =
+		useContext(MatchContext);
 	const { setMessage } = useContext(ProblemContext);
 	const navigate = useNavigate();
 
@@ -82,19 +83,19 @@ function Match() {
 					<>
 						<CoolButton
 							text={"Easy"}
-							loading={findMatch}
+							loading={findMatch || !hasInit}
 							onClick={() => getMatch("Easy")}
 							disabled={!hasInit}
 						/>
 						<CoolButton
 							text={"Medium"}
-							loading={findMatch}
+							loading={findMatch || !hasInit}
 							onClick={() => getMatch("Medium")}
 							disabled={!hasInit}
 						/>
 						<CoolButton
 							text={"Hard"}
-							loading={findMatch}
+							loading={findMatch || !hasInit}
 							onClick={() => getMatch("Hard")}
 							disabled={!hasInit}
 						/>


### PR DESCRIPTION
Make it clearer to user that something is loading in the backend instead of just grey buttons and loading cursor
Updated run-dev.sh script in match-service to run  processes concurrently